### PR TITLE
Update debug from 2.6.8 to 2.6.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -623,8 +623,8 @@
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
       "requires": {
         "ms": "2.0.0"


### PR DESCRIPTION
Github says there is a vulnerability in 2.6.8
Not sure if the "integrity" sha fingerprint needs to change or not, @mbonaci ?